### PR TITLE
gpio: davinci: test PR with meta data

### DIFF
--- a/drivers/gpio/gpiolib.h
+++ b/drivers/gpio/gpiolib.h
@@ -115,11 +115,6 @@ struct gpio_array {
 	unsigned long		invert_mask[];
 };
 
-#define for_each_gpio_desc(gc, desc)					\
-	for (unsigned int __i = 0;					\
-	     __i < gc->ngpio && (desc = gpiochip_get_desc(gc, __i));	\
-	     __i++)							\
-
 #define for_each_gpio_desc_with_flag(gc, desc, flag)			\
 	for_each_gpio_desc(gc, desc)					\
 		if (!test_bit(flag, &desc->flags)) {} else

--- a/include/linux/gpio/driver.h
+++ b/include/linux/gpio/driver.h
@@ -813,6 +813,11 @@ const char *gpio_device_get_label(struct gpio_device *gdev);
 struct gpio_device *gpio_device_find_by_label(const char *label);
 struct gpio_device *gpio_device_find_by_fwnode(const struct fwnode_handle *fwnode);
 
+#define for_each_gpio_desc(gc, desc)					\
+	for (unsigned int __i = 0;					\
+	     __i < gc->ngpio && (desc = gpiochip_get_desc(gc, __i));	\
+	     __i++)							\
+
 #else /* CONFIG_GPIOLIB */
 
 #include <asm/bug.h>


### PR DESCRIPTION
A more full description.

Would go here.

With even more here, followed by some tags, then trailers with diffstat and another with "basement" trailers like b4 would do.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>
---
Kevin Hilman (3):
      pmdomain: ti_sci: add per-device latency constraint management
      pmdomain: ti_sci: add wakeup constraint management
      pmdomain: ti_sci: handle wake IRQs for IO daisy chain wakeups

 drivers/pmdomain/ti/ti_sci_pm_domains.c | 124 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 123 insertions(+), 1 deletion(-)
---
base-commit: ad7eb1b6b92ee0c959a0a6ae846ddadd7a79ea64
change-id: 20240802-lpm-v6-10-constraints-pmdomain-f33df5aef449
prerequisite-message-id: <20240801195422.2296347-1-msp@baylibre.com>
prerequisite-patch-id: 57f574b3f686c62cc0e255f52b2b8b96cd8b1661
prerequisite-patch-id: 0dc60150f10bbd6e0d7ae19001075b859d7af2f1
prerequisite-patch-id: f4b971122cc54df199c0d95a6c4ed47db1dae027
JIRA-ID: [BLF-127]

